### PR TITLE
Adding missing dependencies in the spec for artii and asciiart

### DIFF
--- a/vimdeck.gemspec
+++ b/vimdeck.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |s|
   s.files        = FileList['**/**/*'].exclude /.git|.svn|.DS_Store/
   s.bindir       = 'bin'
   s.executables  = ['vimdeck']
+  s.add_runtime_dependency 'artii'
+  s.add_runtime_dependency 'asciiart'
 end


### PR DESCRIPTION
When I installed the vimdeck 0.0.8 gem it failed immediately and stated that I was missing the `artii` and `asciiart` gems when it tried to `require` them.  I have added them to the `gemspec` file and they are now installed/downloaded when `gem install vimdeck` is issued.
