### PR TITLE
Disable Vim's line numbering when showing slides

### DIFF
--- a/lib/templates/script.vim.erb
+++ b/lib/templates/script.vim.erb
@@ -1,3 +1,4 @@
+set nonumber
 noremap <PageUp> :bp<CR>
 noremap <Left> :bp<CR>
 noremap <PageDown> :bn<CR>


### PR DESCRIPTION
In my .vimrc, line numbering is activated by default, but it renders poorly when in presentation mode...
