### PR TITLE
set buffers to hidden

### DIFF
--- a/lib/templates/script.vim.erb
+++ b/lib/templates/script.vim.erb
@@ -1,4 +1,5 @@
 set nonumber
+set hidden
 noremap <PageUp> :bp<CR>
 noremap <Left> :bp<CR>
 noremap <PageDown> :bn<CR>


### PR DESCRIPTION
changing buffers looses all SyntaxRange settings if buffers (slides)
are abandoned. If they stay hidden, everything is fine.

fixes issue #7
