### PR TITLE
Disable automatic filetype detection

### DIFF
--- a/lib/templates/script.vim.erb
+++ b/lib/templates/script.vim.erb
@@ -1,5 +1,8 @@
 set nonumber
 set hidden
+set filetype=txt
+filetype off
+
 noremap <PageUp> :bp<CR>
 noremap <Left> :bp<CR>
 <% if @options[:mouse_enabled] -%>


### PR DESCRIPTION
This makes sure Vim treats every slide as a simple txt file, instead of trying to guess the file type and applying weird formatting rules.
