### PR TITLE
Also disable relative line numbers

### DIFF
--- a/lib/templates/script.vim.erb
+++ b/lib/templates/script.vim.erb
@@ -1,4 +1,7 @@
 set nonumber
+if exists('+relativenumber')
+  set norelativenumber
+end
 set hidden
 <% if @options[:no_filetype] %>
 argdo set filetype=txt


### PR DESCRIPTION
If Vim has the relative line numbers option, then make sure to disable those as well.
