### PR TITLE
Disable folding

### DIFF
--- a/lib/templates/script.vim.erb
+++ b/lib/templates/script.vim.erb
@@ -1,4 +1,5 @@
 set nonumber
+set nofoldenable
 if exists('+relativenumber')
   set norelativenumber
 end


### PR DESCRIPTION
The entire document is automatically folded if 
```
set foldmethod=indent
set foldlevel=2
```
is in the vimrc. 