### PR TITLE
hide rulers

### DIFF
--- a/lib/templates/script.vim.erb
+++ b/lib/templates/script.vim.erb
@@ -3,6 +3,7 @@ set nonumber
 set nofoldenable
 set nocursorcolumn
 set nocursorline
+set colorcolumn=0
 if exists('+relativenumber')
   set norelativenumber
 end


### PR DESCRIPTION
It is possible that the user has a ruler set (`set colorcolumn=80` for example), and that would affect the slides as well.